### PR TITLE
Initial add of ads1220 component

### DIFF
--- a/esphome/components/ads1220/__init__.py
+++ b/esphome/components/ads1220/__init__.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import spi
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["spi"]
+AUTO_LOAD = ["sensor", "voltage_sampler"]
+MULTI_CONF = True
+
+ads1220_ns = cg.esphome_ns.namespace("ads1220")
+ADS1220Component = ads1220_ns.class_("ADS1220Component", cg.Component, spi.SPIDevice)
+
+CONF_CONTINUOUS_MODE = "continuous_mode"
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ADS1220Component),
+            cv.Optional(CONF_CONTINUOUS_MODE, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(spi.spi_device_schema(None))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await spi.register_spi_device(var, config)
+
+    cg.add(var.set_continuous_mode(config[CONF_CONTINUOUS_MODE]))

--- a/esphome/components/ads1220/ads1220.cpp
+++ b/esphome/components/ads1220/ads1220.cpp
@@ -1,0 +1,526 @@
+#include "ads1220.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace ads1220 {
+
+static const char *const TAG = "ADS1220";
+static const uint8_t ADS1220_REGISTER_CONVERSION = 0x00;
+static const uint8_t ADS1220_REGISTER_CONFIG = 0x01;
+
+static const uint8_t ADS1220_DATA_RATE_860_SPS = 0b111;  // 3300_SPS for ADS1015
+
+//ADS1220 SPI commands
+static constexpr uint8_t ADS1220_RESET       {0x06};
+static constexpr uint8_t ADS1220_START       {0x08};    //Send the START/SYNC command (08h) to start converting in continuous conversion mode
+static constexpr uint8_t ADS1220_PWRDOWN     {0x02};
+static constexpr uint8_t ADS1220_RDATA       {0x10};
+static constexpr uint8_t ADS1220_WREG        {0x40};    // write register
+static constexpr uint8_t ADS1220_RREG        {0x20};    // read register
+
+/* registers */
+static constexpr uint8_t ADS1220_CONF_REG_0  {0x00};
+static constexpr uint8_t ADS1220_CONF_REG_1  {0x01};
+static constexpr uint8_t ADS1220_CONF_REG_2  {0x02};
+static constexpr uint8_t ADS1220_CONF_REG_3  {0x03};
+
+
+void ADS1220Component::setup() {
+	ESP_LOGCONFIG(TAG, "Setting up ADS1220...");
+	uint16_t value;
+	uint8_t value_0;
+	uint8_t value_1;
+	uint8_t value_2;
+	uint8_t value_3;
+
+    this->spi_setup();
+    //pinMode(csPin, OUTPUT);
+    //digitalWrite(csPin, HIGH);
+    pinMode(drdyPin, INPUT);
+    
+    //vRef = 2.048;
+    vRef = 3.300;
+    gain = 1;
+    vfsr = vRef/gain;
+    refMeasurement = false;
+    convMode = ADS1220_SINGLE_SHOT;
+    reset();
+    start();
+    uint8_t ctrlVal = 0;
+    bypassPGA(true); // just a test if the ADS1220 is connected
+    value_0 = this->readRegister(ADS1220_CONF_REG_0);
+    value_1 = this->readRegister(ADS1220_CONF_REG_1);
+    value_2 = this->readRegister(ADS1220_CONF_REG_2);
+    value_3 = this->readRegister(ADS1220_CONF_REG_3);
+    ctrlVal = value_0;
+    ctrlVal = ctrlVal & 0x01;
+    bypassPGA(false);
+    if (!ctrlVal) {
+        ESP_LOGE(TAG, "Communication with ADS1220 failed!");
+        //this->mark_failed();
+        //return;
+    }
+
+	ESP_LOGCONFIG(TAG, "Configuring ADS1220...");
+
+    // Setup operation mode
+    setOperatingMode(ADS1220_TURBO_MODE);
+    // Setup Gain
+    setGain(ADS1220_GAIN_1);
+    // Set mode
+    if (this->continuous_mode_) {
+        // Set continuous mode
+        setConversionMode(ADS1220_CONTINUOUS);
+    } else {
+        // Set singleshot mode
+        setConversionMode(ADS1220_SINGLE_SHOT);
+    }
+    // Set data rate - 860 samples per second (we're in singleshot mode)
+    setDataRate(ADS1220_DR_LVL_4);
+    setVRefSource(ADS1220_VREF_AVDD_AVSS);
+    setDrdyMode(ADS1220_DRDY_ONLY);
+}
+void ADS1220Component::dump_config() {
+    ESP_LOGCONFIG(TAG, "Setting up ADS1220...");
+    //LOG_I2C_DEVICE(this);
+    if (this->is_failed()) {
+        ESP_LOGE(TAG, "Communication with ADS1220 failed!");
+    }
+    
+    for (auto *sensor : this->sensors_) {
+        LOG_SENSOR("  ", "Sensor", sensor);
+        ESP_LOGCONFIG(TAG, "    Multiplexer: %u", sensor->get_multiplexer());
+        ESP_LOGCONFIG(TAG, "    Gain: %u", sensor->get_gain());
+        ESP_LOGCONFIG(TAG, "    Resolution: %u", sensor->get_resolution());
+    }
+}
+
+
+
+
+
+/***********************************
+ * 
+ * Request measurement
+ * 
+ **********************************/
+float ADS1220Component::request_measurement(ADS1220Sensor *sensor) {
+    float resultInMV = 0.0;
+    float resultInVoltage = 0.000;
+    
+    uint16_t config = 0;
+
+    config = sensor->get_multiplexer();
+    setCompareChannels((ads1220Multiplexer)config);
+
+    config = sensor->get_gain();
+    setGain((ads1220Gain)config);
+    //setGain(sensor->get_gain);
+    //setCompareChannels(sensor->get_multiplexer());
+    //setCompareChannels(ADS1220_MULTIPLEXER_P0_NG);
+    resultInMV = getVoltage_mV();
+    resultInVoltage = resultInMV / 1000.0;
+    
+    this->status_clear_warning();
+    return resultInVoltage;
+}
+
+
+
+
+/***********************************
+ * 
+ * Set configuration
+ * 
+ **********************************/
+/* Configuration Register 0 settings */
+void ADS1220Component::setCompareChannels(ads1220Multiplexer mux){
+    if((mux == ADS1220_MULTIPLEXER_REFPX_REFNX_4) || (mux == ADS1220_MULTIPLEXER_AVDD_M_AVSS_4)){
+        gain = 1;    // under these conditions gain is one by definition
+        refMeasurement = true;
+    }
+    else{            // otherwise read gain from register
+        regValue = spi_device_register_0_buffered;//readRegister(ADS1220_CONF_REG_0);
+        regValue = regValue & 0x0E;
+        regValue = regValue>>1;
+        gain = 1 << regValue;
+        refMeasurement = false;
+    }
+    regValue = spi_device_register_0_buffered;//readRegister(ADS1220_CONF_REG_0);
+    regValue &= ~0xF1;
+    regValue |= mux;
+    regValue |= !(doNotBypassPgaIfPossible & 0x01);
+
+    //ESP_LOGI(TAG, "Write compare channels in ADS1220 to value %u", regValue);
+    writeRegister(ADS1220_CONF_REG_0, regValue);
+    if((mux >= 0x80) && (mux <=0xD0)){
+        if(gain > 4){
+            gain = 4;           // max gain is 4 if single-ended input is chosen or PGA is bypassed
+        }
+        forcedBypassPGA();
+    }
+}
+
+void ADS1220Component::setGain(ads1220Gain enumGain) {
+    regValue = readRegister(ADS1220_CONF_REG_0);
+    ads1220Multiplexer mux = (ads1220Multiplexer)(regValue & 0xF0);
+    regValue &= ~0x0E;
+    regValue |= enumGain;
+    writeRegister(ADS1220_CONF_REG_0, regValue);
+
+    gain = 1<<(enumGain>>1);
+    if((mux >= 0x80) && (mux <=0xD0)){
+        if(gain > 4){
+            gain = 4;   // max gain is 4 if single-ended input is chosen or PGA is bypassed
+        }
+        forcedBypassPGA();
+    }
+}
+
+uint8_t ADS1220Component::getGainFactor(){
+    return gain;
+}
+
+void ADS1220Component::bypassPGA(bool bypass){
+    regValue = readRegister(ADS1220_CONF_REG_0);
+    regValue &= ~0x01;
+    regValue |= bypass;
+    doNotBypassPgaIfPossible = !(bypass & 0x01);
+    writeRegister(ADS1220_CONF_REG_0, regValue);
+}
+
+bool ADS1220Component::isPGABypassed(){
+    regValue = readRegister(ADS1220_CONF_REG_0);
+    return regValue & 0x01;
+}
+
+/* Configuration Register 1 settings */
+void ADS1220Component::setDataRate(ads1220DataRate rate){
+    regValue = readRegister(ADS1220_CONF_REG_1);
+    regValue &= ~0xE0;
+    regValue |= rate;
+    writeRegister(ADS1220_CONF_REG_1, regValue);
+}
+
+void ADS1220Component::setOperatingMode(ads1220OpMode mode){
+    regValue = readRegister(ADS1220_CONF_REG_1);
+    regValue &= ~0x18;
+    regValue |= mode;
+    writeRegister(ADS1220_CONF_REG_1, regValue);
+}
+
+void ADS1220Component::setConversionMode(ads1220ConvMode mode){
+    convMode = mode;
+    regValue = readRegister(ADS1220_CONF_REG_1);
+    regValue &= ~0x04;
+    regValue |= mode;
+    writeRegister(ADS1220_CONF_REG_1, regValue);
+}
+
+void ADS1220Component::enableTemperatureSensor(bool enable){
+    regValue = readRegister(ADS1220_CONF_REG_1);
+    if(enable){
+        regValue |= 0x02;
+    }
+    else{
+        regValue &= ~0x02;
+    }
+    writeRegister(ADS1220_CONF_REG_1, regValue);
+}
+
+void ADS1220Component::enableBurnOutCurrentSources(bool enable){
+    regValue = readRegister(ADS1220_CONF_REG_1);
+    if(enable){
+        regValue |= 0x01;
+    }
+    else{
+        regValue &= ~0x01;
+    }
+    writeRegister(ADS1220_CONF_REG_1, regValue);
+}
+
+
+/* Configuration Register 2 settings */
+void ADS1220Component::setVRefSource(ads1220VRef vRefSource){
+    regValue = readRegister(ADS1220_CONF_REG_2);
+    regValue &= ~0xC0;
+    regValue |= vRefSource;
+    writeRegister(ADS1220_CONF_REG_2, regValue);
+}
+
+void ADS1220Component::setFIRFilter(ads1220FIR fir){
+    regValue = readRegister(ADS1220_CONF_REG_2);
+    regValue &= ~0x30;
+    regValue |= fir;
+    writeRegister(ADS1220_CONF_REG_2, regValue);
+}
+
+void ADS1220Component::setLowSidePowerSwitch(ads1220PSW psw){
+    regValue = readRegister(ADS1220_CONF_REG_2);
+    regValue &= ~0x08;
+    regValue |= psw;
+    writeRegister(ADS1220_CONF_REG_2, regValue);
+}
+
+void ADS1220Component::setIdacCurrent(ads1220IdacCurrent current){
+    regValue = readRegister(ADS1220_CONF_REG_2);
+    regValue &= ~0x07;
+    regValue |= current;
+    writeRegister(ADS1220_CONF_REG_2, regValue);
+    //delayMicroseconds(200);
+}
+
+/* Configuration Register 3 settings */
+
+void ADS1220Component::setIdac1Routing(ads1220IdacRouting route){
+    regValue = readRegister(ADS1220_CONF_REG_3);
+    regValue &= ~0xE0;
+    regValue |= (route<<5);
+    writeRegister(ADS1220_CONF_REG_3, regValue);
+}
+
+void ADS1220Component::setIdac2Routing(ads1220IdacRouting route){
+    regValue = readRegister(ADS1220_CONF_REG_3);
+    regValue &= ~0x1C;
+    regValue |= (route<<2);
+    writeRegister(ADS1220_CONF_REG_3, regValue);
+}
+
+void ADS1220Component::setDrdyMode(ads1220DrdyMode mode){
+    regValue = readRegister(ADS1220_CONF_REG_3);
+    regValue &= ~0x02;
+    regValue |= mode;
+    writeRegister(ADS1220_CONF_REG_3, regValue);
+}
+
+/* Other settings */
+void ADS1220Component::setVRefValue_V(float refVal){
+    vRef = refVal;
+}
+
+float ADS1220Component::getVRef_V(){
+    return vRef;
+}
+
+void ADS1220Component::setAvddAvssAsVrefAndCalibrate(){
+    float avssVoltage = 0.0;
+    setVRefSource(ADS1220_VREF_AVDD_AVSS);
+    setCompareChannels(ADS1220_MULTIPLEXER_AVDD_M_AVSS_4);
+    for(int i = 0; i<10; i++){
+        avssVoltage += getVoltage_mV();
+    }
+    vRef = avssVoltage * 4.0 / 10000.0;
+}
+
+void ADS1220Component::setRefp0Refn0AsVefAndCalibrate(){
+    float ref0Voltage = 0.0;
+    setVRefSource(ADS1220_VREF_REFP0_REFN0);
+    setCompareChannels(ADS1220_MULTIPLEXER_REFPX_REFNX_4);
+    for(int i = 0; i<10; i++){
+        ref0Voltage += getVoltage_mV();
+    }
+    vRef = ref0Voltage * 4.0 / 10000.0;
+}
+
+void ADS1220Component::setRefp1Refn1AsVefAndCalibrate(){
+    float ref1Voltage = 0.0;
+    setVRefSource(ADS1220_VREF_REFP1_REFN1);
+    setCompareChannels(ADS1220_MULTIPLEXER_REFPX_REFNX_4);
+    for(int i = 0; i<10; i++){
+        ref1Voltage += getVoltage_mV();
+    }
+    vRef = ref1Voltage * 4.0 / 10000.0;
+}
+
+void ADS1220Component::setIntVRef(){
+    setVRefSource(ADS1220_VREF_INT);
+    vRef = 2.048;
+}
+
+
+/* Results */
+float ADS1220Component::getVoltage_mV(){
+    int32_t rawData = getData();
+    float resultInMV = 0.0;
+    if(refMeasurement){
+        resultInMV = (rawData / ADS1220_RANGE) * 2.048 * 1000.0 / (gain * 1.0);
+    }
+    else{
+        resultInMV = (rawData / ADS1220_RANGE) * vRef * 1000.0 / (gain * 1.0);
+    }
+    return (float)((rawData*vfsr*1000)/ADS1220_RANGE);
+    //return resultInMV;
+}
+
+float ADS1220Component::getVoltage_muV(){
+    return getVoltage_mV() * 1000.0;
+}
+
+int32_t ADS1220Component::getRawData(){
+    return getData();
+}
+
+float ADS1220Component::getTemperature(){
+    enableTemperatureSensor(true);
+    uint32_t rawResult = readResult();
+    enableTemperatureSensor(false);
+
+    uint16_t result = static_cast<uint16_t>(rawResult >> 18);
+    if(result>>13){
+        result = ~(result-1) & 0x3777;
+        return result * (-0.03125);
+    }
+
+    return result * 0.03125;
+}
+
+/************************************************
+    private functions
+*************************************************/
+
+void ADS1220Component::forcedBypassPGA(){
+    regValue = spi_device_register_0_buffered;//readRegister(ADS1220_CONF_REG_0);
+    if (!(regValue & 0x01))
+    {
+        regValue |= 0x01;
+        //ESP_LOGI(TAG, "Write forcedBypassPGA in ADS1220 to value %u", regValue);
+        writeRegister(ADS1220_CONF_REG_0, regValue);
+    }
+}
+
+int32_t ADS1220Component::getData(){
+    uint32_t rawResult = readResult();
+    int32_t result = (static_cast<int32_t>(rawResult)) >> 8;
+
+    return result;
+}
+
+uint32_t ADS1220Component::readResult()
+{
+    uint8_t data[4] = { 0x00 };
+    uint32_t rawResult = 0;
+
+    //ESP_LOGI(TAG, "Read result from ADS1220!");
+    //delay(1);
+
+    if(convMode == ADS1220_SINGLE_SHOT){
+        //ESP_LOGI(TAG, "Start conversion!");
+        //delay(1);
+        start();
+    }
+    while(digitalRead(drdyPin)) {}
+
+    //ESP_LOGI(TAG, "Store result to memory!");
+    //delay(1);
+    
+    this->enable();
+    delay(1);
+    
+    data[0] = this->read_byte();
+    data[1] = this->read_byte();
+    data[2] = this->read_byte();
+
+    this->disable();
+    delay(1);
+
+    rawResult = data[0];
+    rawResult = (rawResult << 8) | data[1];
+    rawResult = (rawResult << 8) | data[2];
+    rawResult = (rawResult << 8);
+
+    return rawResult;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+void ADS1220Component::reset() {
+    send_command(ADS1220_RESET);
+}
+
+void ADS1220Component::start() {
+    send_command(ADS1220_START);
+}
+
+uint8_t ADS1220Component::readRegister(uint8_t reg)
+{
+    uint8_t data[4] = { 0x00 };;
+
+    this->enable();
+    delay(1);
+
+    this->write_byte(ADS1220_RREG | (reg<<2));
+
+    data[0] = this->read_byte();
+    data[1] = this->read_byte();
+    data[2] = this->read_byte();
+
+    this->disable();
+    delay(1);
+
+    return data[0];
+}
+
+void ADS1220Component::writeRegister(uint8_t reg, uint8_t val)
+{
+    if (reg == ADS1220_CONF_REG_0)
+        spi_device_register_0_buffered = val;
+    if (reg == ADS1220_CONF_REG_1)
+        spi_device_register_1_buffered = val;
+    if (reg == ADS1220_CONF_REG_2)
+        spi_device_register_2_buffered = val;
+    if (reg == ADS1220_CONF_REG_3)
+        spi_device_register_3_buffered = val;
+
+    this->enable();
+    delay(1);
+
+    this->write_byte(ADS1220_WREG | (reg<<2));
+    this->write_byte(val);
+
+    this->disable();
+    delay(1);
+
+}
+
+void ADS1220Component::send_command(uint8_t cmd)
+{
+    //ESP_LOGI(TAG, "Send command %u to ADS1220", cmd);
+    
+    this->enable();
+    delay(1);
+    
+    this->write_byte(cmd);
+
+    this->disable();
+    delay(1);
+}
+
+
+
+
+
+float ADS1220Sensor::sample() {
+    return this->parent_->request_measurement(this);
+}
+
+void ADS1220Sensor::update() {
+  float v = this->parent_->request_measurement(this);
+  if (!std::isnan(v)) {
+    ESP_LOGD(TAG, "'%s': Got Voltage=%fV", this->get_name().c_str(), v);
+    this->publish_state(v);
+  }
+}
+
+}  // namespace ads1220
+}  // namespace esphome

--- a/esphome/components/ads1220/ads1220.h
+++ b/esphome/components/ads1220/ads1220.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include "esphome.h"
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/voltage_sampler/voltage_sampler.h"
+
+#include <vector>
+
+namespace esphome {
+namespace ads1220 {
+
+typedef enum ADS1220Multiplexer {
+    ADS1220_MULTIPLEXER_P0_N1 = 0x00,   //default
+    ADS1220_MULTIPLEXER_P0_N2 = 0x10,
+    ADS1220_MULTIPLEXER_P0_N3 = 0x20,
+    ADS1220_MULTIPLEXER_P1_N2 = 0x30,
+    ADS1220_MULTIPLEXER_P1_N3 = 0x40,
+    ADS1220_MULTIPLEXER_P2_N3 = 0x50,
+    ADS1220_MULTIPLEXER_P1_N0 = 0x60,
+    ADS1220_MULTIPLEXER_P3_N2 = 0x70,
+    ADS1220_MULTIPLEXER_P0_NG = 0x80,
+    ADS1220_MULTIPLEXER_P1_NG = 0x90,
+    ADS1220_MULTIPLEXER_P2_NG = 0xA0,
+    ADS1220_MULTIPLEXER_P3_NG = 0xB0,
+    ADS1220_MULTIPLEXER_REFPX_REFNX_4 = 0xC0,
+    ADS1220_MULTIPLEXER_AVDD_M_AVSS_4 = 0xD0,
+    ADS1220_MULTIPLEXER_AVDD_P_AVSS_2 = 0xE0
+} ads1220Multiplexer;
+
+typedef enum ADS1220Gain {
+    ADS1220_GAIN_1   = 0x00,   //default
+    ADS1220_GAIN_2   = 0x02,
+    ADS1220_GAIN_4   = 0x04,
+    ADS1220_GAIN_8   = 0x06,
+    ADS1220_GAIN_16  = 0x08,
+    ADS1220_GAIN_32  = 0x0A,
+    ADS1220_GAIN_64  = 0x0C,
+    ADS1220_GAIN_128 = 0x0E
+} ads1220Gain;
+
+typedef enum ADS1220DataRate {
+    ADS1220_DR_LVL_0 = 0x00,   // default
+    ADS1220_DR_LVL_1 = 0x20,
+    ADS1220_DR_LVL_2 = 0x40,
+    ADS1220_DR_LVL_3 = 0x60,
+    ADS1220_DR_LVL_4 = 0x80,
+    ADS1220_DR_LVL_5 = 0xA0,
+    ADS1220_DR_LVL_6 = 0xC0
+} ads1220DataRate;
+
+typedef enum ADS1220OpMode {
+    ADS1220_NORMAL_MODE     = 0x00,  // default
+    ADS1220_DUTY_CYCLE_MODE = 0x08,
+    ADS1220_TURBO_MODE      = 0x10
+} ads1220OpMode;
+
+typedef enum ADS1220ConvMode {
+    ADS1220_SINGLE_SHOT     = 0x00,  // default
+    ADS1220_CONTINUOUS      = 0x04
+} ads1220ConvMode;
+
+typedef enum ADS1220VRef {
+    ADS1220_VREF_INT            = 0x00,  // default
+    ADS1220_VREF_REFP0_REFN0    = 0x40,
+    ADS1220_VREF_REFP1_REFN1    = 0x80,
+    ADS1220_VREF_AVDD_AVSS      = 0xC0
+} ads1220VRef;
+
+typedef enum ADS1220_FIR{
+    ADS1220_NONE        = 0x00,   // default
+    ADS1220_50HZ_60HZ   = 0x10,
+    ADS1220_50HZ        = 0x20,
+    ADS1220_60HZ        = 0x30
+} ads1220FIR;
+
+typedef enum ADS1220PSW {
+    ADS1220_ALWAYS_OPEN = 0x00,  // default
+    ADS1220_SWITCH      = 0x08
+} ads1220PSW;
+
+typedef enum ADS1220_IDAC_CURRENT {
+    ADS1220_IDAC_OFF        = 0x00,  // defaulr
+    ADS1220_IDAC_10_MU_A    = 0x01,
+    ADS1220_IDAC_50_MU_A    = 0x02,
+    ADS1220_IDAC_100_MU_A   = 0x03,
+    ADS1220_IDAC_250_MU_A   = 0x04,
+    ADS1220_IDAC_500_MU_A   = 0x05,
+    ADS1220_IDAC_1000_MU_A  = 0x06,
+    ADS1220_IDAC_1500_MU_A  = 0x07
+} ads1220IdacCurrent;
+
+typedef enum ADS1220IdacRouting {
+    ADS1220_IDAC_NONE       = 0x00,  // default
+    ADS1220_IDAC_AIN0_REFP1 = 0x01,
+    ADS1220_IDAC_AIN1       = 0x02,
+    ADS1220_IDAC_AIN2       = 0x03,
+    ADS1220_IDAC_AIN3_REFN1 = 0x04,
+    ADS1220_IDAC_REFP0      = 0x05,
+    ADS1220_IDAC_REFN0      = 0x06,
+} ads1220IdacRouting;
+
+typedef enum ADS1220DrdyMode {
+    ADS1220_DRDY_ONLY = 0x00,   // default
+    ADS1220_DOUT_DRDY = 0x02
+} ads1220DrdyMode;
+
+typedef enum ADS1220Resolution {
+    ADS1220_24_BITS = 24,
+} ads1220Resolution;
+
+class ADS1220Sensor;
+
+class ADS1220Component : public Component, public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_1MHZ> {
+    public:
+        void register_sensor(ADS1220Sensor *obj) { this->sensors_.push_back(obj); }
+        /// Set up the internal sensor array.
+        void setup() override;
+        void dump_config() override;
+        /// HARDWARE_LATE setup priority
+        float get_setup_priority() const override { return setup_priority::DATA; }
+        void set_continuous_mode(bool continuous_mode) { continuous_mode_ = continuous_mode; }
+    
+        /// Helper method to request a measurement from a sensor.
+        float request_measurement(ADS1220Sensor *sensor);
+
+     protected:
+        std::vector<ADS1220Sensor *> sensors_;
+        uint16_t prev_config_{0};
+        bool continuous_mode_ = false;
+
+        uint8_t csPin;
+        uint8_t drdyPin = 0;
+        uint8_t regValue;
+        float vRef;
+        uint8_t gain;
+        float vfsr;
+        bool refMeasurement;
+        ads1220ConvMode convMode;
+        bool doNotBypassPgaIfPossible = false;
+        InternalGPIOPin *drdy_pin{nullptr};
+
+        uint8_t spi_device_register_0_buffered;
+        uint8_t spi_device_register_1_buffered;
+        uint8_t spi_device_register_2_buffered;
+        uint8_t spi_device_register_3_buffered;
+        float channel_0_voltage;
+        float channel_1_voltage;
+        float channel_2_voltage;
+        float channel_3_voltage;
+        static constexpr float ADS1220_RANGE {8388607.0}; // = 2^23 - 1 as float
+
+        /* Configuration Register 0 settings */
+        void setCompareChannels(ads1220Multiplexer mux);
+        void setGain(ads1220Gain gain);
+        uint8_t getGainFactor();
+        void bypassPGA(bool bypass);
+        bool isPGABypassed();
+
+        /* Configuration Register 1 settings */
+        void setDataRate(ads1220DataRate rate);
+        void setOperatingMode(ads1220OpMode mode);
+        void setConversionMode(ads1220ConvMode mode);
+        void enableTemperatureSensor(bool enable);
+        void enableBurnOutCurrentSources(bool enable);
+
+        /* Configuration Register 2 settings */
+        void setVRefSource(ads1220VRef vRefSource);
+        void setFIRFilter(ads1220FIR fir);
+        void setLowSidePowerSwitch(ads1220PSW psw);
+        void setIdacCurrent(ads1220IdacCurrent current);
+
+        /* Configuration Register 3 settings */
+        void setIdac1Routing(ads1220IdacRouting route);
+        void setIdac2Routing(ads1220IdacRouting route);
+        void setDrdyMode(ads1220DrdyMode mode);
+
+        /* Other settings */
+        void setVRefValue_V(float refVal);
+        float getVRef_V();
+        void setAvddAvssAsVrefAndCalibrate();
+        void setRefp0Refn0AsVefAndCalibrate();
+        void setRefp1Refn1AsVefAndCalibrate();
+        void setIntVRef();
+
+        /* Results */
+        float getVoltage_mV();
+        float getVoltage_muV();
+        int32_t getRawData();
+        float getTemperature();
+
+        void reset();
+        void start();
+
+        void forcedBypassPGA();
+        int32_t getData();
+        uint32_t readResult();
+        uint8_t readRegister(uint8_t reg);
+        void writeRegister(uint8_t reg, uint8_t val);
+        void send_command(uint8_t cmd);
+    
+};
+
+/// Internal holder class that is in instance of Sensor so that the hub can create individual sensors.
+class ADS1220Sensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
+    public:
+        ADS1220Sensor(ADS1220Component *parent) : parent_(parent) {}
+        void update() override;
+        void set_multiplexer(ADS1220Multiplexer multiplexer) { multiplexer_ = multiplexer; }
+        void set_gain(ADS1220Gain gain) { gain_ = gain; }
+        void set_resolution(ADS1220Resolution resolution) { resolution_ = resolution; }
+        float sample() override;
+        uint8_t get_multiplexer() const { return multiplexer_; }
+        uint8_t get_gain() const { return gain_; }
+        uint8_t get_resolution() const { return resolution_; }
+    
+    protected:
+        ADS1220Component *parent_;
+        ADS1220Multiplexer multiplexer_;
+        ADS1220Gain gain_;
+        ADS1220Resolution resolution_;
+};
+
+}  // namespace ads1220
+}  // namespace esphome

--- a/esphome/components/ads1220/sensor.py
+++ b/esphome/components/ads1220/sensor.py
@@ -1,0 +1,100 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, voltage_sampler
+from esphome.const import (
+    CONF_GAIN,
+    CONF_MULTIPLEXER,
+    CONF_RESOLUTION,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_VOLT,
+    CONF_ID,
+)
+from . import ads1220_ns, ADS1220Component
+
+DEPENDENCIES = ["ads1220"]
+
+ADS1220Multiplexer = ads1220_ns.enum("ADS1220Multiplexer")
+MUX = {
+    "A0_A1": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P0_N1,
+    "A0_A2": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P0_N2,
+    "A0_A3": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P0_N3,
+    "A1_A2": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P1_N2,
+    "A1_A3": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P1_N3,
+    "A2_A3": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P2_N3,
+    "A1_A0": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P1_N0,
+    "A3_A2": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P3_N2,
+    "A0_GND": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P0_NG,
+    "A1_GND": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P1_NG,
+    "A2_GND": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P2_NG,
+    "A3_GND": ADS1220Multiplexer.ADS1220_MULTIPLEXER_P3_NG,
+    "REFPX_REFNX_4": ADS1220Multiplexer.ADS1220_MULTIPLEXER_REFPX_REFNX_4,
+    "AVDD_M_AVSS_4": ADS1220Multiplexer.ADS1220_MULTIPLEXER_AVDD_M_AVSS_4,
+    "AVDD_P_AVSS_2": ADS1220Multiplexer.ADS1220_MULTIPLEXER_AVDD_P_AVSS_2,
+}
+
+ADS1220Gain = ads1220_ns.enum("ADS1220Gain")
+GAIN = {
+    "1": ADS1220Gain.ADS1220_GAIN_1,
+    "2": ADS1220Gain.ADS1220_GAIN_2,
+    "4": ADS1220Gain.ADS1220_GAIN_4,
+    "8": ADS1220Gain.ADS1220_GAIN_8,
+    "16": ADS1220Gain.ADS1220_GAIN_16,
+    "32": ADS1220Gain.ADS1220_GAIN_32,
+    "64": ADS1220Gain.ADS1220_GAIN_64,
+    "128": ADS1220Gain.ADS1220_GAIN_128,
+}
+
+ADS1220Resolution = ads1220_ns.enum("ADS1220Resolution")
+RESOLUTION = {
+    "24_BITS": ADS1220Resolution.ADS1220_24_BITS,
+}
+
+
+def validate_gain(value):
+    if isinstance(value, float):
+        value = f"{value:0.03f}"
+    elif not isinstance(value, str):
+        raise cv.Invalid(f'invalid gain "{value}"')
+
+    return cv.enum(GAIN)(value)
+
+
+ADS1220Sensor = ads1220_ns.class_(
+    "ADS1220Sensor", sensor.Sensor, cg.PollingComponent, voltage_sampler.VoltageSampler
+)
+
+CONF_ADS1220_ID = "ads1220_id"
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        ADS1220Sensor,
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=3,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(
+        {
+            cv.GenerateID(CONF_ADS1220_ID): cv.use_id(ADS1220Component),
+            cv.Required(CONF_MULTIPLEXER): cv.enum(MUX, upper=True, space="_"),
+            cv.Required(CONF_GAIN): validate_gain,
+            cv.Optional(CONF_RESOLUTION, default="24_BITS"): cv.enum(
+                RESOLUTION, upper=True, space="_"
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    paren = await cg.get_variable(config[CONF_ADS1220_ID])
+    var = cg.new_Pvariable(config[CONF_ID], paren)
+    await sensor.register_sensor(var, config)
+    await cg.register_component(var, config)
+
+    cg.add(var.set_multiplexer(config[CONF_MULTIPLEXER]))
+    cg.add(var.set_gain(config[CONF_GAIN]))
+    cg.add(var.set_resolution(config[CONF_RESOLUTION]))
+
+    cg.add(paren.register_sensor(var))


### PR DESCRIPTION
# What does this implement/fix?

Adding ads1220 A/D converter component

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:
spi:
  id: spi_bus0
  clk_pin: 4
  mosi_pin: 6
  miso_pin: 5
  interface: hardware

ads1220:
  spi_id: spi_bus0
  cs_pin: 7

sensor:
  - platform: ads1220
    name: "ADS1220 Channel A0-GND"
    multiplexer: 'A0_GND'
    gain: '1'
    update_interval: 2s
    accuracy_decimals: 3

  - platform: ads1220
    name: "ADS1220 Channel A1-GND"
    multiplexer: 'A1_GND'
    gain: '1'
    update_interval: 2s
    accuracy_decimals: 3

  - platform: ads1220
    name: "ADS1220 Channel A2-GND"
    multiplexer: 'A2_GND'
    gain: '1'
    update_interval: 2s
    accuracy_decimals: 3

  - platform: ads1220
    name: "ADS1220 Channel A3-GND"
    multiplexer: 'A3_GND'
    gain: '1'
    update_interval: 2s
    accuracy_decimals: 3

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
